### PR TITLE
Feature tests notebook

### DIFF
--- a/heeps/coronagraphs/vortex.py
+++ b/heeps/coronagraphs/vortex.py
@@ -38,8 +38,8 @@ def vortex(wfo, conf):
             # vortex phase ramp is oversampled for a better discretization
             ramp_oversamp = 11.
             nramp = int(gridsize*ramp_oversamp)
-            start = -nramp/2 - int(ramp_oversamp)/2
-            end   =  nramp/2 - int(ramp_oversamp)/2
+            start = -nramp/2 - int(ramp_oversamp)/2 + 0.5
+            end   =  nramp/2 - int(ramp_oversamp)/2 + 0.5
             Vp = np.arange(start, end, 1.)
             # Pancharatnam Phase = arg<Vref,Vp> (horizontal input polarization)
             Vref = np.ones(Vp.shape)

--- a/tests/tests_perfectCoronagraphs.ipynb
+++ b/tests/tests_perfectCoronagraphs.ipynb
@@ -1,0 +1,256 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Examples and simple tests with HEEPS"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook is intended to illustrate and verify basic properties of perfect vortex coronagraphs: the CVC and the RAVC."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Perfect Classical Vortex Coronagraph with a circular aperture"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib widget\n",
+    "import proper\n",
+    "from heeps.config import conf\n",
+    "from heeps.pupil import pupil\n",
+    "from heeps.coronagraphs import apodization, vortex, lyotstop, lyot\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import astropy.units as u\n",
+    "from astropy.io import fits \n",
+    "\n",
+    "import heeps.util.img_processing as impro"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "npupil = 9\n"
+     ]
+    }
+   ],
+   "source": [
+    "'''\n",
+    "Gridsize is very small on-purpose to be able to examine pixel-wise.\n",
+    "This is not intended for a real e2e simulation, just for illustration\n",
+    "\n",
+    "conf['pupil_file'] = '', in order to have a proper circular pupil\n",
+    "'''\n",
+    "conf['gridsize']=32\n",
+    "conf['diam']=10\n",
+    "conf['lam'] = 2.2e-6 \n",
+    "conf['pscale'] = 11.4\n",
+    "conf['R_obstr'] = 0 \n",
+    "conf['get_amp'] =True\n",
+    "conf['get_phase'] = True\n",
+    "conf['spiders_width'] = False\n",
+    "conf['pupil_file'] = ''\n",
+    "\n",
+    "\n",
+    "wf, pup_amp, pup_phase = pupil(conf)\n",
+    "vortex(wf, conf)\n",
+    "before_lyot = impro.crop_img(proper.prop_get_amplitude(wf), conf['npupil'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4a9feca5a65f452ea60e03792db56865",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Canvas(toolbar=Toolbar(toolitems=[('Home', 'Reset original view', 'home', 'home'), ('Back', 'Back to previous …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Text(0.5, 1.0, 'Intensity in the Lyot plane \\n (before Lyot stop)')"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "plt.figure()\n",
+    "plt.subplot(121)\n",
+    "plt.imshow(pup_amp)\n",
+    "plt.title('Intensity in the \\n pupil plane')\n",
+    "\n",
+    "plt.subplot(122)\n",
+    "plt.imshow(before_lyot)\n",
+    "plt.title('Intensity in the Lyot plane \\n (before Lyot stop)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Perfect Ring Apodized Vortex Coronagraph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading input files from Google Drive to '/Users/orban/github/HEEPS/tests/input_files/'.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%matplotlib widget\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import astropy.units as u\n",
+    "from astropy.io import fits \n",
+    "from astropy.visualization import imshow_norm,\\\n",
+    "    SqrtStretch, MinMaxInterval, PercentileInterval, ManualInterval,\\\n",
+    "    LinearStretch, SinhStretch, LogStretch\n",
+    "from heeps.config import conf\n",
+    "from heeps.pupil import pupil\n",
+    "from heeps.aberrations import wavefront_aberrations\n",
+    "from heeps.coronagraphs import apodization, vortex, lyotstop, lyot\n",
+    "from heeps.detector import detector\n",
+    "import heeps.util.img_processing as impro\n",
+    "from copy import deepcopy\n",
+    "import proper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "npupil = 251\n"
+     ]
+    }
+   ],
+   "source": [
+    "conf['spiders_width'] = 0.0\n",
+    "conf['LS_params'] = [0.98, 0.03, 0]  \n",
+    "conf['get_amp'] = True\n",
+    "conf['get_phase'] = True\n",
+    "conf['hfov'] = 0.666   \n",
+    "conf['pupil_file'] = ''\n",
+    "\n",
+    "wf_start, pup_amp, pup_phase = pupil(conf)    \n",
+    "wf = deepcopy(wf_start)\n",
+    "\n",
+    "wf, apo_amp, apo_phase = apodization(wf, conf, RAVC=True)\n",
+    "vortex(wf, conf)\n",
+    "wf, LS_amp, LS_phase = lyotstop(wf, conf, RAVC=True, APP=False)\n",
+    "\n",
+    "conf['ndet'] = int(np.ceil(2*conf['hfov']*1000/conf['pscale']))    \n",
+    "if conf['ndet'] %2 :\n",
+    "    conf['ndet'] += 1\n",
+    "psf = detector(wf, conf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6cbf78465ae4491995348efc964d101a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Canvas(toolbar=Toolbar(toolitems=[('Home', 'Reset original view', 'home', 'home'), ('Back', 'Back to previous …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Text(0.5, 1.0, 'Post-coronagraph PSF')"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "plt.figure()\n",
+    "im, norm = imshow_norm(psf, plt.gca(), origin='lower',\n",
+    "                       interval=MinMaxInterval(),\n",
+    "                       stretch=LogStretch())\n",
+    "plt.colorbar(im)\n",
+    "plt.title('Post-coronagraph PSF')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
I propose to add a folder with different tests and examples. This is not intended to illustrate end-to-end propagation but to verify basic properties and check that the code is performing correctly.

To start, I commit here two basic examples for the CVC and the RAVC, to verify the vortex centering (see Issue #26 ).
In this PR, I have already included the vortex shift (Issue #26) and it also supposed that the issue in `pupil.py` is fixed (see #27 ).